### PR TITLE
Added DateModified and HTMList components

### DIFF
--- a/src/components/DateModified.js
+++ b/src/components/DateModified.js
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+
+export function DateModified(props) {
+  // TeamCity build dates are received in the format yyyyMMdd
+  const dateFormatted = props.date
+    ? props.date.replace(/^(.{4})(.{2})/gm, "$1-$2-")
+    : "NA";
+  return (
+    <dl className="mt-8 py-2 font-body font-normal text-sm">
+      <dt className="inline">{props.label}</dt>
+      <dd className="inline">
+        {dateFormatted === "NA" ? (
+          <time>{` ${dateFormatted}`}</time>
+        ) : (
+          <time dateTime={dateFormatted}>{` ${dateFormatted}`}</time>
+        )}
+      </dd>
+    </dl>
+  );
+}
+
+DateModified.defaultProps = {
+  label: "Date Modified: ",
+};
+
+DateModified.propTypes = {
+  /**
+   * Text to show before date, defaults to "Date Modified: "
+   */
+  label: PropTypes.string,
+
+  // Date string in format yyyyMMdd
+  date: PropTypes.string,
+};

--- a/src/components/DateModified.stories.js
+++ b/src/components/DateModified.stories.js
@@ -1,0 +1,15 @@
+import { DateModified } from "./DateModified";
+
+export default {
+  title: "Components/Page details/DateModified",
+  component: DateModified,
+};
+
+const Template = (args) => <DateModified {...args} />;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  date: "20200420",
+  label: "Date modified: ",
+};

--- a/src/components/DateModified.test.js
+++ b/src/components/DateModified.test.js
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Primary } from "./DateModified.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("DateModified", () => {
+  it("renders and formats the date properly", () => {
+    render(<Primary {...Primary.args} />);
+    screen.getByText("2020-04-20");
+  });
+
+  it("renders 'NA' as date if date is undefined", () => {
+    render(<Primary />);
+    screen.getByText("NA");
+  });
+
+  it("renders the label properly", () => {
+    render(<Primary {...Primary.args} />);
+    screen.getByText("Date modified: ");
+  });
+
+  it("has no a11y violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/DateModified.test.js
+++ b/src/components/DateModified.test.js
@@ -20,7 +20,7 @@ describe("DateModified", () => {
 
   it("renders the label properly", () => {
     render(<Primary {...Primary.args} />);
-    screen.getByText("Date modified: ");
+    screen.getByText("Date modified:");
   });
 
   it("has no a11y violations", async () => {

--- a/src/components/HTMList.js
+++ b/src/components/HTMList.js
@@ -1,0 +1,26 @@
+import PropTypes from "prop-types";
+
+export function HTMList({ tag = "ul", content, listClassName, liClassName }) {
+  const parseList = (content) =>
+    content
+      .split("*") // split the string on asterisks
+      .filter((item) => item) // filter out empty strings
+      .map((item, index) => (
+        <li className={liClassName} key={index}>
+          {item.trim()}
+        </li>
+      ));
+
+  return tag === "ul" ? (
+    <ul className={listClassName}>{parseList(content)}</ul>
+  ) : (
+    <ol className={listClassName}>{parseList(content)}</ol>
+  );
+}
+
+HTMList.propTypes = {
+  tag: PropTypes.string,
+  content: PropTypes.string.isRequired,
+  listClassName: PropTypes.string,
+  liClassName: PropTypes.string,
+};

--- a/src/components/HTMList.stories.js
+++ b/src/components/HTMList.stories.js
@@ -1,0 +1,24 @@
+import { HTMList } from "./HTMList";
+
+export default {
+  title: "Components/Utility/HTMList",
+  component: HTMList,
+};
+
+const Template = (args) => <HTMList {...args} />;
+
+export const UnorderedList = Template.bind({});
+UnorderedList.args = {
+  tag: "ul",
+  content: "* one * two * three",
+  listClassName: "list-disc ml-2",
+  liClassName: "text-custom-blue-dark",
+};
+
+export const OrderedList = Template.bind({});
+OrderedList.args = {
+  tag: "ol",
+  content: "* one * two * three",
+  listClassName: "list-decimal ml-2",
+  liClassName: "text-custom-blue-dark",
+};

--- a/src/components/HTMList.test.js
+++ b/src/components/HTMList.test.js
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import { HTMList } from "./HTMList";
+
+describe("HTMList", () => {
+  it("renders a list of 3 items", () => {
+    render(<HTMList content="* one * two * three" />);
+    const items = screen.getAllByRole("listitem");
+    expect(items.length).toBe(3);
+
+    const itemsArray = items.map((item) => item.textContent);
+    expect(itemsArray).toEqual(["one", "two", "three"]);
+  });
+
+  const listElements = ["ul", "ol"];
+  listElements.map((listElement) => {
+    it(`renders a list of 3 items as an "${listElement}"`, () => {
+      render(<HTMList tag={listElement} content="* one * two * three" />);
+      const items = screen.getAllByRole("listitem");
+      expect(items.length).toBe(3);
+    });
+  });
+
+  it("renders a list of 0 items if empty content", () => {
+    render(<HTMList content="" />);
+    const items = screen.queryAllByRole("listitem");
+    expect(items.length).toBe(0);
+  });
+
+  it("renders a list of 1 item if no asterisk", () => {
+    render(<HTMList content="one two three" />);
+    const items = screen.queryAllByRole("listitem");
+    expect(items.length).toBe(1);
+  });
+
+  it("renders a list of 1 item if 1 asterisk at the start", () => {
+    render(<HTMList content="* one two three" />);
+    const items = screen.queryAllByRole("listitem");
+    expect(items.length).toBe(1);
+  });
+
+  it("renders a list of 2 items if 1 asterisk in the middle of the string", () => {
+    render(<HTMList content="one two * three" />);
+    const items = screen.queryAllByRole("listitem");
+    expect(items.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Description

In this PR:
- I've added the DateModified component and modified the props to include a label (with a default value of `Date Modified: `, rather than having translation in the component itself
- I've added the HTMList component and added a stories file with an ordered and unordered list as an example

## Steps to test
1. Pull in branch
2. Type `npm i` then `npm run storybook`
3. Navigate through each component to confirm each work as they should

## Checklist
- [x] Tests are included

## Trello Board
https://trello.com/c/eEMzchij