### PR TITLE
Added SelectField and CallToAction Components

### DIFF
--- a/src/components/CallToAction.js
+++ b/src/components/CallToAction.js
@@ -1,0 +1,85 @@
+import PropTypes from "prop-types";
+import { ActionButton } from "./ActionButton";
+
+/**
+ * A section that will have a title, small description, and a link to some action we want to user to make
+ */
+export function CallToAction(props) {
+  return (
+    <aside>
+      <div className="bg-circle-color text-white">
+        <div className="layout-container pb-10 pt-10 text-sm md:text-base">
+          <h2>{props.title}</h2>
+          <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24 gap-5">
+            {props.description ? (
+              <p className="whitespace-pre-line">{props.description}</p>
+            ) : (
+              <div
+                className="whitespace-pre-line"
+                dangerouslySetInnerHTML={{ __html: props.html }}
+              />
+            )}
+            <div>
+              <p className="flex mb-4 text-center">
+                <ActionButton
+                  id="become-a-participant-btn"
+                  custom={
+                    "py-2 px-4 rounded text-custom-blue-projects-link bg-details-button-gray hover:bg-gray-300 border border-custom-blue-blue active:bg-custom-blue-dark active:border-2 active:border-white hover:border-2 hover:border-white"
+                  }
+                  className=""
+                  href={props.href}
+                  text={props.hrefText}
+                />
+              </p>
+              <p>
+                <a
+                  href={props.privacyLink}
+                  className="text-sm underline flex xl:inline lg:mr-10"
+                >
+                  {props.privacyLinkText}
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+CallToAction.propTypes = {
+  /**
+   * title of the call to action
+   */
+  title: PropTypes.string.isRequired,
+
+  /**
+   * a short description about what the call to action is about - string format
+   */
+  description: PropTypes.string,
+
+  /**
+   * a short description about what the call to action is about - html format
+   */
+  html: PropTypes.string,
+
+  /**
+   * the url to the action
+   */
+  href: PropTypes.string.isRequired,
+
+  /**
+   * url text to be displayed
+   */
+  hrefText: PropTypes.string.isRequired,
+
+  /**
+   * the url to the privacy policy
+   */
+  privacyLink: PropTypes.string.isRequired,
+
+  /**
+   * url text to be displayed for the privacy link
+   */
+  privacyLinkText: PropTypes.string.isRequired,
+};

--- a/src/components/CallToAction.stories.js
+++ b/src/components/CallToAction.stories.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { CallToAction } from "./CallToAction";
+
+export default {
+  title: "Components/Redirect Components/CallToAction",
+  component: CallToAction,
+};
+
+const Template = (args) => <CallToAction {...args} />;
+
+export const Primary = Template.bind({});
+export const Secondary = Template.bind({});
+Primary.args = {
+  title: "the title",
+  description: "a description that should be short and concise",
+  href: "#",
+  hrefText: "the link text",
+  privacyLink: "/",
+  privacyLinkText: "Review the privacy policy",
+};
+
+Secondary.args = {
+  title: "the title",
+  html: "<h1>Title</h1><p>Text</p>",
+  href: "#",
+  hrefText: "the link text",
+  privacyLink: "/",
+  privacyLinkText: "Review the privacy policy",
+};

--- a/src/components/CallToAction.test.js
+++ b/src/components/CallToAction.test.js
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { Primary, Secondary } from "./CallToAction.stories";
+import { axe, toHaveNoViolations } from "jest-axe";
+
+expect.extend(toHaveNoViolations);
+
+describe("CallToAction", () => {
+  it("renders component correctly", () => {
+    render(<Primary {...Primary.args} />);
+    screen.getByText(Primary.args.title);
+    screen.getByText(Primary.args.description);
+    screen.getByText(Primary.args.hrefText);
+    screen.getByText(Primary.args.privacyLinkText);
+  });
+
+  it("renders the html content with some text", () => {
+    render(<Secondary {...Secondary.args} />);
+    screen.getByText(Secondary.args.title);
+    screen.getByText("Title");
+    screen.getByText("Text");
+    screen.getByText(Secondary.args.hrefText);
+    screen.getByText(Secondary.args.privacyLinkText);
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/SelectField.js
+++ b/src/components/SelectField.js
@@ -1,0 +1,175 @@
+import PropTypes from "prop-types";
+import { ErrorLabel } from "./ErrorLabel";
+
+export function SelectField(props) {
+  const ifControlledProps = !props.uncontrolled
+    ? {
+        value: props.value,
+      }
+    : {};
+
+  props.options.sort(function (a, b) {
+    var collator = new Intl.Collator("fr");
+    return collator.compare(a.name.toLowerCase(), b.name.toLowerCase());
+  });
+
+  return (
+    <div
+      className={`block leading-tight${
+        props.className ? " " + props.className : " mb-10px"
+      }`}
+    >
+      <label
+        className={`select-field-label block leading-tight text-sm lg:text-p font-body mb-5 ${
+          props.boldLabel ? "font-bold" : ""
+        }`}
+        htmlFor={props.id + "-choice"}
+      >
+        {props.required ? (
+          <b className="text-error-border-red">*</b>
+        ) : undefined}{" "}
+        {props.label}{" "}
+        {props.required ? (
+          <b className="text-error-border-red">{props.requiredText}</b>
+        ) : (
+          <span className="inline text-form-input-gray text-sm lg:text-p">
+            {props.optionalText}
+          </span>
+        )}
+      </label>
+      {props.error ? <ErrorLabel message={props.error} /> : undefined}
+      <select
+        className={`text-input select-field bg-white font-body w-full min-h-40px shadow-sm border-2 py-6px px-12px ${
+          props.error ? "border-error-border-red" : "border-black"
+        }`}
+        id={props.id + "-choice"}
+        name={props.name}
+        required={props.required}
+        onChange={(e) => props.onChange(e.currentTarget.value)}
+        {...ifControlledProps}
+        data-testid={props.dataTestId + "-choice"}
+        data-cy={props.dataCy + "-choice"}
+      >
+        <option
+          key="default"
+          value=""
+          data-testid="default"
+          data-cy="default"
+        />
+        {props.options.map(({ id, name, value }) => {
+          return (
+            <option key={id} value={value} data-testid={id} data-cy={id}>
+              {name}
+            </option>
+          );
+        })}
+        {props.other ? (
+          <option
+            key={"other"}
+            value={"other"}
+            data-testid={"other"}
+            data-cy={"other"}
+          >
+            {props.otherText}
+          </option>
+        ) : (
+          ""
+        )}
+      </select>
+    </div>
+  );
+}
+
+SelectField.defaultProps = {
+  value: "",
+};
+
+SelectField.propTypes = {
+  /**
+   * additional css for the component
+   */
+  className: PropTypes.string,
+
+  /**
+   * the id of the text field
+   */
+  id: PropTypes.string.isRequired,
+
+  /**
+   * the name of the text field
+   */
+  name: PropTypes.string.isRequired,
+
+  /**
+   * the label of the text field
+   */
+  label: PropTypes.string.isRequired,
+
+  /**
+   * whether ot not the field is required
+   */
+  required: PropTypes.bool,
+
+  /**
+   * the text to show after the label in parenthesis if the field is required
+   */
+  requiredText: PropTypes.string.isRequired,
+
+  /**
+   * the text to show after the label in parenthesis if the field is optional
+   */
+  optionalText: PropTypes.string.isRequired,
+
+  /**
+   * disclaimer text to not disclose any personal information
+   */
+  otherText: PropTypes.string.isRequired,
+
+  /**
+   * value of the text field
+   */
+  value: PropTypes.string.isRequired,
+
+  /**
+   * call back for when the value of the text field changes
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * message to display if there is an error
+   */
+  error: PropTypes.string,
+
+  /**
+   * Other option for dropdown
+   */
+  other: PropTypes.bool,
+
+  /**
+   * if label should be bold
+   */
+  boldLabel: PropTypes.bool,
+
+  /**
+   * boolean flag to specify that this input should be uncontrolled by react
+   */
+  uncontrolled: PropTypes.bool,
+
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    })
+  ),
+
+  /**
+   * unit test selector
+   */
+  dataTestId: PropTypes.string,
+
+  /**
+   * cypress tests selector
+   */
+  dataCy: PropTypes.string,
+};

--- a/src/components/SelectField.stories.js
+++ b/src/components/SelectField.stories.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { SelectField } from "./SelectField";
+
+export default {
+  title: "Components/Form Components/SelectField",
+  component: SelectField,
+  decorators: [
+    (Story) => (
+      <div className="w-full flex justify-center">
+        <div className="w-96">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+const Template = (args) => <SelectField {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  id: "select-field-1",
+  name: "selectField1",
+  label: "I am a select field",
+  uncontrolled: true,
+  dataTestId: "select-field-1",
+  required: true,
+  requiredText: "(required)",
+  options: [
+    {
+      id: "option1",
+      name: "Option 1",
+      value: "option1",
+    },
+    {
+      id: "option2",
+      name: "Option 2",
+      value: "option2",
+    },
+    {
+      id: "option3",
+      name: "Option 3",
+      value: "option3",
+    },
+    {
+      id: "option4",
+      name: "Option 4",
+      value: "option4",
+    },
+  ],
+  other: true,
+  otherText: "Other",
+};

--- a/src/components/SelectField.test.js
+++ b/src/components/SelectField.test.js
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Primary } from "./SelectField.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("SelectField", () => {
+  let mockFn;
+  beforeEach(() => {
+    mockFn = jest.fn();
+  });
+  afterEach(() => {
+    mockFn.mockRestore();
+  });
+  // TODO could not find a way to test selecting item from data list
+  it("renders field", () => {
+    render(<Primary {...Primary.args} onChange={mockFn} />);
+    const inputElem = screen.getByTestId("select-field-1-choice");
+    expect(inputElem.value).toBe("");
+  });
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Description

In this PR:
- I've added the SelectField component and modified props to include `requiredText` and `optionalText` as well as the `otherText` prop if the `other` prop is true
- I've added the CallToAction component and modified props to include `privacyLink` and `privacyLinkText` to replace the hardcoded link and the link text that was previously using translation inside the component. I also removed `Link`. I wasn't sure what type of component I should classify the CallToAction as, so for now it is listed under `Redirect Components`. I'm not sure this is an ideal category name though so I'm open to suggestions.

## Steps to test
1. Pull in branch
2. Type `npm i` then `npm run storybook`
3. Navigate through each component to confirm each work as they should

## Checklist
- [x] Tests are included

## Trello Board
https://trello.com/c/eEMzchij