### PR TITLE
Added List and Menu components

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -1,0 +1,41 @@
+import PropTypes from "prop-types";
+
+/**
+ *  List component
+ */
+export function List(props) {
+  let opacity = 40;
+  return (
+    <ul className={props.className}>
+      {props.items.map((item, key) => {
+        let className =
+          "bg-opacity-" +
+          opacity +
+          " bg-circle-color text-shadow-about-circles flex-shrink-0 mr-4 mb-2 rounded-full h-36 w-36 flex items-center justify-center text-white font-bold font-display text-h1xxl relative md:left-0 -left-14";
+        if (opacity < 100) opacity += 20;
+        return (
+          <li key={key} className="flex">
+            <span className={className} role="presentation">
+              {key + 1}
+            </span>
+            <p className="text-sm md:text-p my-auto leading-normal font-body">
+              {item}
+            </p>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+List.propTypes = {
+  /**
+   * List items
+   */
+  items: PropTypes.arrayOf(String).isRequired,
+
+  /**
+   * Option for styling component
+   */
+  className: PropTypes.string,
+};

--- a/src/components/List.stories.js
+++ b/src/components/List.stories.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { List } from "./List";
+
+export default {
+  title: "Components/Molecules/List",
+  component: List,
+};
+
+const Template = (args) => <List {...args}></List>;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  items: ["Item 1", "Item 2", "Item 3", "Item 4"],
+};

--- a/src/components/List.stories.js
+++ b/src/components/List.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import { List } from "./List";
 
 export default {
-  title: "Components/Molecules/List",
+  title: "Components/Informative Components/List",
   component: List,
 };
 

--- a/src/components/List.test.js
+++ b/src/components/List.test.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Primary } from "./List.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("List", () => {
+  it("renders the list with some items", () => {
+    render(<Primary {...Primary.args} />);
+    Primary.args.items.forEach((value) => {
+      screen.getByText(value);
+    });
+  });
+
+  it("has no a11y violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,0 +1,101 @@
+import PropTypes from "prop-types";
+
+/**
+ * Menu component
+ */
+export function Menu(props) {
+  const path = window.location.pathname;
+
+  //Function for changing menu state
+  function onMenuClick() {
+    const menuButton = document.getElementById("menuButton");
+    const menuDropdown = document.getElementById("menuDropdown");
+
+    menuDropdown.classList.toggle("active");
+    menuButton.getAttribute("aria-expanded") === "true"
+      ? menuButton.setAttribute("aria-expanded", false)
+      : menuButton.setAttribute("aria-expanded", true);
+  }
+
+  return (
+    <nav
+      title="Menu"
+      className="layout-container lg:justify-end lg:flex"
+      data-cy="menu"
+      role="navigation"
+      aria-labelledby="mainSiteNav"
+    >
+      <h3 className="sr-only" id="mainSiteNav">
+        Menu
+      </h3>
+      <button
+        id="menuButton"
+        onClick={onMenuClick}
+        className="text-h4 text-canada-footer-font focus:outline-none focus:ring-2 focus:ring-black mb-4 py-1"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="menuDropdown"
+        data-testid="menuButton"
+      >
+        <span className="inline-block align-middle icon-menu" />
+        <span className="inline-block align-middle pl-3 font-body text-p leading-none">
+          {props.menuButtonTitle}
+        </span>
+      </button>
+
+      <ul id="menuDropdown" className="menuDropdown" role="menu">
+        {props.items.map((item, key) => {
+          const exactURL = path === item.link; // it's exactly this url
+          const includesURL = path.includes(item.link); // it's a child of this url (eg, "/projects/app" includes "/projects")
+
+          return (
+            <li
+              key={key}
+              className={`py-3 lg:py-0 cursor-pointer text-custom-blue-projects-link `}
+              role="menuitem"
+              aria-current={exactURL ? "page" : null}
+            >
+              <a
+                href={item.link}
+                className={`font-body text-base ${
+                  includesURL ? "activePage" : "menuLink underline"
+                }`}
+              >
+                {item.text}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+Menu.propTypes = {
+  /**
+   * Menu title for small screens
+   */
+  menuButtonTitle: PropTypes.string.isRequired,
+
+  /**
+   * text for sign up button
+   */
+  signUpText: PropTypes.string.isRequired,
+
+  /**
+   * Array of Items for the menu
+   */
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * Text for the menu
+       */
+      text: PropTypes.string,
+
+      /**
+       * Link for the menu
+       */
+      link: PropTypes.string,
+    })
+  ).isRequired,
+};

--- a/src/components/Menu.stories.js
+++ b/src/components/Menu.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Menu } from "./Menu";
 
 export default {
-  title: "Components/Molecules/Menu",
+  title: "Components/Redirect Components/Menu",
   component: Menu,
 };
 

--- a/src/components/Menu.stories.js
+++ b/src/components/Menu.stories.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { Menu } from "./Menu";
+
+export default {
+  title: "Components/Molecules/Menu",
+  component: Menu,
+};
+
+const Template = (args) => <Menu {...args}></Menu>;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  menuButtonTitle: "Menu",
+  signUpText: "Sign up",
+  items: [
+    {
+      link: "#",
+      text: "Link1",
+    },
+    {
+      link: "#",
+      text: "Link2",
+    },
+    {
+      link: "#",
+      text: "Link3",
+    },
+  ],
+};

--- a/src/components/Menu.test.js
+++ b/src/components/Menu.test.js
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Primary } from "./Menu.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("Menu", () => {
+  it("renders the menu", () => {
+    render(<Primary {...Primary.args} />);
+    screen.getByTitle("Menu");
+  });
+
+  it("toggles aria-expanded attribute when clicked", () => {
+    render(<Primary {...Primary.args} />);
+    const inputElem = screen.getByTestId("menuButton");
+    act(() => {
+      inputElem.click();
+    });
+    expect(inputElem.getAttribute("aria-expanded")).toEqual("true");
+  });
+
+  it("has no a11y violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,7 @@ module.exports = {
       h1: ["36px", "42px"],
       h1l: ["38px", "42px"],
       h1xl: ["45px", "54px"],
+      h1xxl: ["70px", "84px"],
     },
     screens: {
       xxs: "280px",


### PR DESCRIPTION
## Description

In this PR:
- I've added the List component (I have the directory set as Informative Components for the time being but this may change if I come up with something more appropriate)
- I've added the Menu component and removed the Next router functionality to instead use `window.location.pathname` to retrieve the URL path that determines styling
- Added the h1xxl font style to tailwind

## Steps to test
1. Pull in branch
2. Type `npm i` then `npm run storybook`
3. Navigate through each component to confirm each work as they should

## Checklist
- [x] Tests are included

## Trello Board
https://trello.com/c/eEMzchij