### PR TITLE
Button accept enum for style

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -73,9 +73,12 @@ Button.propTypes = {
    * to their button. To apply the link style, the user must
    * also add a value to the href prop
    */
-  styling: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.oneOf(["supertask", "primary", "secondary", "danger", "link"]),
+  styling: PropTypes.oneOf([
+    "supertask",
+    "primary",
+    "secondary",
+    "danger",
+    "link",
   ]).isRequired,
 
   /**


### PR DESCRIPTION
Button accepts enum for style

Change makes Button only accept enum values. Currently it accepts either a string or one of the enum values.