### PR TITLE
Added husky to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "@testing-library/user-event": "^12.8.3",
         "eslint-plugin-jest": "^25.2.4",
         "fetch-mock": "^9.11.0",
-        "joi": "^17.4.2"
+        "husky": "^6.0.0",
+        "joi": "^17.4.2",
+        "prettier": "^2.2.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.14.5",
@@ -42,12 +44,10 @@
         "eslint": "7.32.0",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.27.1",
-        "husky": "^6.0.0",
         "jest-axe": "^5.0.1",
         "lint-staged": "^11.0.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.6",
-        "prettier": "^2.2.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "5.0.0",
@@ -17196,7 +17196,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/husky/-/husky-6.0.0.tgz",
       "integrity": "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==",
-      "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
@@ -25084,7 +25083,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -46771,8 +46769,7 @@
     "husky": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/husky/-/husky-6.0.0.tgz",
-      "integrity": "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==",
-      "dev": true
+      "integrity": "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -52754,8 +52751,7 @@
     "prettier": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@testing-library/user-event": "^12.8.3",
     "eslint-plugin-jest": "^25.2.4",
     "fetch-mock": "^9.11.0",
+    "husky": "^6.0.0",
+    "prettier": "^2.2.1",
     "joi": "^17.4.2"
   },
   "peerDependencies": {
@@ -96,12 +98,10 @@
     "eslint": "7.32.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.27.1",
-    "husky": "^6.0.0",
     "jest-axe": "^5.0.1",
     "lint-staged": "^11.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.6",
-    "prettier": "^2.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",


### PR DESCRIPTION
Fixed production publish.

Missing Husky was throwing errors when trying to publish npm package manually.