### PR TITLE
Set accordion line height within design system

### DIFF
--- a/src/components/AccordionForm/AccordionForm.js
+++ b/src/components/AccordionForm/AccordionForm.js
@@ -82,7 +82,10 @@ export function AccordionForm(props) {
           <div className="ds-flex-col ds-pb-12px">
             <div className="cardNumber ds-flex ds-flex-row">
               <div className="ds-relative ds-rounded-full ds-w-48px ds-h-48px ds-bg-multi-blue-blue60d">
-                <p className="ds-absolute ds-left-3.5 ds-bottom-0.5 ds-accordion-num">
+                <p
+                  className="ds-absolute ds-left-3.5 ds-bottom-0.5 ds-accordion-num"
+                  style={{ lineHeight: "48px" }}
+                >
                   {index + 1}
                 </p>
               </div>

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -102,6 +102,11 @@
   opacity: 0.08;
   pointer-events: none;
 }
+
+.ds-accordion-num {
+  line-height: 48px;
+}
+
 /* 
 input[type="radio"]:checked + .ds-label {
   border-color: #0e62c9;

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -102,11 +102,6 @@
   opacity: 0.08;
   pointer-events: none;
 }
-
-.ds-accordion-num {
-  line-height: 48px;
-}
-
 /* 
 input[type="radio"]:checked + .ds-label {
   border-color: #0e62c9;


### PR DESCRIPTION
In implementing the Accordion Form in EE, I've noticed that your component does not properly set its own line height. We have a global style in EE that sets line height in a way that breaks your component. The solution is to set the line height in your component. I've done this directly in the form's js file, but I am pretty sure this isn't the "right" way of doing things. All I know is it fixes it on desktop. Haven't tested on mobile.

This is how it looks in EE after the changes in this PR are applied:
![image](https://user-images.githubusercontent.com/3630698/162271546-214b171e-087e-4437-aabf-640a28be783b.png)

And this is how it looks like before, note the spacing of the numbers:
![image](https://user-images.githubusercontent.com/3630698/162274161-e99a9a90-dc79-49d0-9c79-a95aa1286ac4.png)

I also have a second commit in which I tried to fix this via css files, but for some reason I don't understand, it does not work.

So, I am hoping you can use this PR as a starting point to properly fix this issue. However it would be totally fine if you just took my first commit and merged that in. Let me know and I can remove the second commit. You should also be able to push your own changes to my branch, as you would if it was your own branch.

Note: to easily review this commit locally, since this is in a different repository (I don't have write access to your repo), I recommend using the [GitHub CLI](https://cli.github.com/). It'll clone and switch branches automatically! See the code button at the top right of this page for more info.