### PR TITLE
added exposed after pattern examples and clean up code, removed unsed…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Checkboxes Component
 - Review and Submit Template
 - FormMultiTextField Component
+- Consequential Call Out Examples
+- Exposed After Pattern Examples
 
 ### Changed
 

--- a/src/components/FormLabel/FormLabel.js
+++ b/src/components/FormLabel/FormLabel.js
@@ -11,18 +11,18 @@ export function FormLabel(props) {
         className={`ds-flex ds-text-multi-neutrals-grey100 ds-items-center ds-leading-24px ds-text-xl lg:ds-text-p ds-font-body ds-mb-8px ds-relative`}
         htmlFor={props.id}
       >
-        <div className="ds-inline ds-text-form-input-gray lg:ds-text-xl ds-whitespace-nowrap ds-font-bold ">
+        <div className="ds-inline ds-text-form-input-gray lg:ds-text-xl ds-font-bold ">
           {props.label}{" "}
+          {props.required ? (
+            <p className="ds-inline ds-text-error-border-red ds-text-xl ds-font-medium">
+              &nbsp;{`(${props.requiredText})`}
+            </p>
+          ) : (
+            <p className="ds-inline ds-text-form-input-gray ds-text-xl lg:ds-text-xl ds-font-medium">
+              &nbsp;{`(${props.optionalText})`}
+            </p>
+          )}
         </div>
-        {props.required ? (
-          <div className="ds-text-error-border-red ds-text-xl ds-font-medium">
-            &nbsp;{`(${props.requiredText})`}
-          </div>
-        ) : (
-          <div className="ds-inline ds-text-form-input-gray ds-text-xl lg:ds-text-xl ds-font-medium">
-            &nbsp;{`(${props.optionalText})`}
-          </div>
-        )}
         {props.infoText && (
           <div
             className="ds-infoText ds-cursor-pointer ds-ml-auto md:ds-ml-0 ds-pl-8px"
@@ -96,11 +96,6 @@ FormLabel.propTypes = {
    * Unit test selector
    */
   dataTestId: PropTypes.string,
-
-  /**
-   * cypress tests selector
-   */
-  dataCy: PropTypes.string,
 
   /**
    * Exclude option for adding exclude class to the textfield

--- a/src/components/FormRadioButton/FormRadioButton.js
+++ b/src/components/FormRadioButton/FormRadioButton.js
@@ -37,7 +37,6 @@ export function FormRadioButton(props) {
               props.onChange(value, e);
             }}
             data-testid={`${id}-${props.dataTestId}`}
-            data-cy={props.dataCy}
             checked={checked}
             defaultChecked={false}
           />
@@ -101,9 +100,4 @@ FormRadioButton.propTypes = {
    * unit test selector
    */
   dataTestId: PropTypes.string,
-
-  /**
-   * cypress test selector
-   */
-  dataCy: PropTypes.string,
 };

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -12,11 +12,7 @@ export function TextField(props) {
       }
     : {};
   return (
-    <div
-      className={`ds-block ds-leading-tight ${
-        props.className ? " " + props.className : "ds-mb-10px"
-      }`}
-    >
+    <div className={`ds-block ds-leading-tight ds-mb-10px`}>
       {props.label && (
         <FormLabel
           id={props.id}
@@ -30,7 +26,9 @@ export function TextField(props) {
         />
       )}
       <input
-        className={`ds-rounded ds-outline-0 ds-text-input ds-text-mobileh5 ds-text-multi-neutrals-grey100 ds-w-full ds-min-h-44px ds-text-form-input-gray ds-border-1.5 ds-py-5px ds-px-14px ${
+        className={`${
+          props.className
+        } ds-rounded ds-outline-0 ds-text-input ds-text-mobileh5 ds-text-multi-neutrals-grey100 ds-w-full ds-min-h-44px ds-text-form-input-gray ds-border-1.5 ds-py-5px ds-px-14px ${
           props.hasError
             ? "ds-border-specific-red-red50b"
             : "ds-border-multi-neutrals-grey85a focus:ds-border-multi-blue-blue60f"
@@ -47,7 +45,6 @@ export function TextField(props) {
         onChange={(e) => props.onChange(e.currentTarget.value)}
         {...ifControlledProps}
         data-testid={props.dataTestId}
-        data-cy={props.dataCy}
       />
       {props.hasError && <FormError errorMessage={props.errorText} />}
     </div>
@@ -75,6 +72,22 @@ TextField.propTypes = {
    * the name of the text field
    */
   name: PropTypes.string.isRequired,
+
+  /**
+   * The textfield label
+   */
+  label: PropTypes.string.isRequired,
+
+  /**
+   * The text which fills in the parenthesis, next to the label
+   */
+  requiredText: PropTypes.string,
+
+  /**
+   * The text directly below the label text, used to give more information
+   * inregards to the given input
+   */
+  helpText: PropTypes.string,
 
   /**
    * value of the text field
@@ -125,11 +138,6 @@ TextField.propTypes = {
    * unit test selector
    */
   dataTestId: PropTypes.string,
-
-  /**
-   * cypress tests selector
-   */
-  dataCy: PropTypes.string,
 
   /**
    * Exclude option for adding exclude class to the textfield

--- a/src/storyExamples/AfterPattern/AfterPattern.js
+++ b/src/storyExamples/AfterPattern/AfterPattern.js
@@ -1,0 +1,25 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+/**
+ * The following is a coding examples of how you would implement an Exposed After Pattern,
+ * using our components within your own project repo. View Canvas tab to interract with the example and
+ * to view a code example, go to the docs tab and click on "Show code" button located to the bottom right,
+ * within the given canvas below.
+ */
+
+export function AfterPattern(props) {
+  const { exampleCode } = props;
+  return <>{exampleCode}</>;
+}
+
+AfterPattern.propTypes = {
+  /**
+   * Refer to "Show code" option within each canvas example
+   */
+  exampleCode: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+    PropTypes.arrayOf(PropTypes.element),
+  ]),
+};

--- a/src/storyExamples/AfterPattern/AfterPattern.stories.js
+++ b/src/storyExamples/AfterPattern/AfterPattern.stories.js
@@ -1,0 +1,73 @@
+import { AfterPattern } from "./AfterPattern";
+import { FormRadioButton } from "../../components/FormRadioButton/FormRadioButton";
+import { TextField } from "../../components/TextField/TextField";
+import React from "react";
+
+export default {
+  title: "Story Examples/Exposed After Pattern",
+  // parameters: {
+  //   viewMode: "docs",
+  //   previewTabs: {
+  //     canvas: { hidden: true },
+  //   },
+  // },
+  component: AfterPattern,
+};
+
+const Template = () => {
+  const [errorState, setErrorState] = React.useState(false);
+  const exampleCode = [
+    <div>
+      <FormRadioButton
+        id="radio-button-2"
+        label="Since the age of 18 years old, have you lived outside of 
+        Canada for longer than 6 months?"
+        name="radio_button_2"
+        required
+        onChange={(value) => {
+          if (value == "yes") {
+            setErrorState(true);
+          } else {
+            setErrorState(false);
+          }
+        }}
+        options={[
+          {
+            id: "option_1",
+            label:
+              "No, I have not lived outside of Canada for longer than 6 months",
+            value: "no",
+          },
+          {
+            id: "option_2",
+            label:
+              "Yes, I have lived outside of Canada for longer than 6 months",
+            value: "yes",
+          },
+        ]}
+      />
+      {errorState ? (
+        <div className="ds-mt-34px">
+          <TextField
+            id="textField1"
+            label="Since the age of 18, how many years have you lived in 
+            Canada?"
+            helpText="If you are not sure of the exact number, you may enter an estimate. 
+            You will still be able to view your eligibility results. "
+            name="textField1"
+            className="ds-w-165px"
+            onChange={() => {}}
+            requiredText="required"
+            uncontrolled
+          />
+        </div>
+      ) : null}
+    </div>,
+  ];
+
+  return <AfterPattern id="test" exampleCode={exampleCode} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -190,6 +190,7 @@ module.exports = {
         "105px": "105px",
         "138px": "138px",
         "160px": "160px",
+        "165px": "165px",
         "168px": "168px",
         "284px": "284px",
         "300px": "300px",
@@ -264,6 +265,7 @@ module.exports = {
       },
 
       maxWidth: {
+        "165px": "165px",
         "168px": "168px",
         "350px": "350px",
         "450px": "450px",


### PR DESCRIPTION
# DS-355/after-pattern

#### Description & Background Context:
Added examples for exposed after pattern, improved documentation for textarea and label components, removed unneeded props in multiple components.

#### Where should the reviewer start?
File name: AfterPattern folder under storyExamples in src

#### How should this be tested?
Review examples on storybook link

#### Are there any breaking changes?
No
