### PR TITLE
Remove memoization to make cards rerender when we need the form to change dynamically

### DIFF
--- a/src/components/AccordionForm/AccordionForm.js
+++ b/src/components/AccordionForm/AccordionForm.js
@@ -59,7 +59,7 @@ export function AccordionForm(props) {
     });
   }, [cardsOpenState]);
 
-  const cardRenders = React.useMemo(() => {
+  const cardRenders = () => {
     return cards.map((card, index, cardsArr) => {
       const isLastCard = !cardsArr[index + 1];
       const isNextFillableCard = cardsOpenState[card.id];
@@ -140,11 +140,11 @@ export function AccordionForm(props) {
         </div>
       );
     });
-  }, [dirtyCards, cardsState]);
+  };
 
   return (
     <form className="AccordionForm" noValidate id={id}>
-      {cardRenders}
+      {cardRenders()}
     </form>
   );
 }


### PR DESCRIPTION
…ange dynamically

# DS-##(Jira Issue)-A###(component ID)-(component name)

**Reminder: Add all changes for this PR to the CHANGELOG.md**

Main Reviewer: @

#### Description & Background Context:

useMemo hook is currently used in AccordionForm that prevents us from changing the form dynamically. The "cards" array and more specifically the individual cards and their children undergo many changes in our form as the user interacts with it. These changes are not picked up by the AccordionForm because useMemo hook is used. Proposing to sacrifice a bit more rerenders for dynamic functionality.

#### Where should the reviewer start?

File name:

#### How should this be tested?

#### Are there any breaking changes?
