### PR TITLE
Accordion Form: Fix card state implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "5.0.0",
-        "rollup": "^2.67.3",
+        "rollup": "~2.75.4",
         "rollup-plugin-delete": "^2.0.0",
         "rollup-plugin-img": "^1.1.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
@@ -28567,9 +28567,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.69.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.69.1.tgz",
-      "integrity": "sha512-xaQKTomUVZBopk38EIshM/kOoPFkKWisgBV7Emy80coP9MOSLUDrba1jKZhqH0iS5DoGcRbbcuyl/BzblV8w5w==",
+      "version": "2.75.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.4.tgz",
+      "integrity": "sha512-JgZiJMJkKImMZJ8ZY1zU80Z2bA/TvrL/7D9qcBCrfl2bP+HUaIw0QHUroB4E3gBpFl6CRFM1YxGbuYGtdAswbQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -55746,9 +55746,9 @@
       }
     },
     "rollup": {
-      "version": "2.69.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.69.1.tgz",
-      "integrity": "sha512-xaQKTomUVZBopk38EIshM/kOoPFkKWisgBV7Emy80coP9MOSLUDrba1jKZhqH0iS5DoGcRbbcuyl/BzblV8w5w==",
+      "version": "2.75.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.4.tgz",
+      "integrity": "sha512-JgZiJMJkKImMZJ8ZY1zU80Z2bA/TvrL/7D9qcBCrfl2bP+HUaIw0QHUroB4E3gBpFl6CRFM1YxGbuYGtdAswbQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",
-    "rollup": "^2.67.3",
+    "rollup": "~2.75.4",
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-img": "^1.1.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",

--- a/src/components/AccordionForm/AccordionForm.js
+++ b/src/components/AccordionForm/AccordionForm.js
@@ -151,7 +151,6 @@ const generateCardOpenStates = (cardsState) => {
     cardsObj[cardId] = cardState.isValid;
     if (!cardState.isValid && !firstInvalidCardId) {
       firstInvalidCardId = cardId;
-      console.log(cardsObj[cardId]);
     }
   });
   // up until here, all invalid ones are false and all valid are true

--- a/src/components/AccordionForm/AccordionForm.js
+++ b/src/components/AccordionForm/AccordionForm.js
@@ -21,7 +21,7 @@ export function AccordionForm(props) {
         e.preventDefault();
         if (cardsState[cardId].isValid) {
           const curIndex = cards.findIndex(({ id }) => {
-            return id == cardId;
+            return id === cardId;
           });
           if (cards[curIndex + 1]) {
             const nextCard = cards[curIndex + 1].id;

--- a/src/components/AccordionForm/AccordionForm.js
+++ b/src/components/AccordionForm/AccordionForm.js
@@ -15,30 +15,33 @@ import { Button } from "../Button/Button";
 export function AccordionForm(props) {
   const { cards, id, cardsState } = props;
   const cardsRefs = cards.map(() => React.useRef(null));
-  const sectionNextClick = React.useCallback((cardId, index) => {
-    return (e) => {
-      e.preventDefault();
-      if (cardsState[cardId].isValid) {
-        const curIndex = cards.findIndex(({ id }) => {
-          return id == cardId;
-        });
-        if (cards[curIndex + 1]) {
-          const nextCard = cards[curIndex + 1].id;
-          setDirtyCards((curDirtyCards) => {
-            return !curDirtyCards.includes(nextCard)
-              ? [...curDirtyCards, nextCard]
-              : curDirtyCards;
+  const sectionNextClick = React.useCallback(
+    (cardId, index) => {
+      return (e) => {
+        e.preventDefault();
+        if (cardsState[cardId].isValid) {
+          const curIndex = cards.findIndex(({ id }) => {
+            return id == cardId;
           });
-          if (cardsRefs[index + 1].current)
-            window.scrollTo({
-              top: cardsRefs[index + 1].current.offsetTop,
-              left: 0,
-              behavior: "smooth",
+          if (cards[curIndex + 1]) {
+            const nextCard = cards[curIndex + 1].id;
+            setDirtyCards((curDirtyCards) => {
+              return !curDirtyCards.includes(nextCard)
+                ? [...curDirtyCards, nextCard]
+                : curDirtyCards;
             });
+            if (cardsRefs[index + 1].current)
+              window.scrollTo({
+                top: cardsRefs[index + 1].current.offsetTop,
+                left: 0,
+                behavior: "smooth",
+              });
+          }
         }
-      }
-    };
-  }, []);
+      };
+    },
+    [cardsState]
+  );
 
   const [cardsOpenState] = React.useState(() => {
     return generateCardOpenStates(cardsState);


### PR DESCRIPTION
This is a pretty straightforward PR, the main update is to add `cardsState` as a dependency for the `sectionNextClick` `React.useCallback`. This is because the `useCallback` memoizes the function, and only updates when its dependencies update. So, I've added `cardsState` as a dependency, so that when `cardsState` updates, the updated version is used by `sectionNextClick`!

I will note that the previous implementation did work, but this was only when using `useState` improperly. It would work when updating the same `cardsState` object rather than returning a new one. However, it is best practice to return a new object, so "React Magic" works as expected. See here for info on why that is bad practice: https://blog.logrocket.com/a-guide-to-usestate-in-react-ecb9952e406c/#usinganobjectasastatevariablewithusestatehook

Two other small commits I've snuck in are simply removing a `console.log()`, and changing from `==` to the generally recommended `===` ([info](https://bytearcher.com/articles/equality-comparison-operator-javascript/)).

Edit: another commit I've added is updating Rollup. This fixes a significant issue for me, allowing us to point directly at Design System GitHub branches in our project's dependencies, meaning we can use develop versions or other branches super easily! We'd greatly appreciate including this commit as well. The issue discussion is here: https://github.com/rollup/rollup/issues/4446

Also, just wanted to mention that you can indeed check out and merge this PR without copying it into a new one, even though the branch is on my own repo. The easiest way to do that is using the Code button in the top right (`gh pr checkout 301`). Please use this PR so that I can better track its status!

Thanks!