### PR TITLE
DatePicker: use numbers as key rather than month name

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -52,33 +52,33 @@ export function DatePicker(props) {
           >
             {lang === "en" ? (
               <>
-                <option value="January">January</option>
-                <option value="February">February</option>
-                <option value="March">March</option>
-                <option value="April">April</option>
-                <option value="May">May</option>
-                <option value="June">June</option>
-                <option value="July">July</option>
-                <option value="August">August</option>
-                <option value="September">September</option>
-                <option value="October">October</option>
-                <option value="November">November</option>
-                <option value="December">December</option>
+                <option value="1">January</option>
+                <option value="2">February</option>
+                <option value="3">March</option>
+                <option value="4">April</option>
+                <option value="5">May</option>
+                <option value="6">June</option>
+                <option value="7">July</option>
+                <option value="8">August</option>
+                <option value="9">September</option>
+                <option value="10">October</option>
+                <option value="11">November</option>
+                <option value="12">December</option>
               </>
             ) : (
               <>
-                <option value="January">Janvier</option>
-                <option value="February">Février</option>
-                <option value="March">Mars</option>
-                <option value="April">Avril</option>
-                <option value="May">Peut</option>
-                <option value="June">Juin</option>
-                <option value="July">Juillet</option>
-                <option value="August">Août</option>
-                <option value="September">Septembre</option>
-                <option value="October">Octobre</option>
-                <option value="November">Novembre</option>
-                <option value="December">Décembre</option>
+                <option value="1">Janvier</option>
+                <option value="2">Février</option>
+                <option value="3">Mars</option>
+                <option value="4">Avril</option>
+                <option value="5">Peut</option>
+                <option value="6">Juin</option>
+                <option value="7">Juillet</option>
+                <option value="8">Août</option>
+                <option value="9">Septembre</option>
+                <option value="10">Octobre</option>
+                <option value="11">Novembre</option>
+                <option value="12">Décembre</option>
               </>
             )}
           </select>

--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -50,37 +50,30 @@ export function DatePicker(props) {
             onChange={onMonthChange}
             className="ds-w-165px ds-py-5px  ds-px-14px ds-date-text ds-border-1.5 ds-border-multi-neutrals-grey85a ds-rounded"
           >
-            {lang === "en" ? (
-              <>
-                <option value="1">January</option>
-                <option value="2">February</option>
-                <option value="3">March</option>
-                <option value="4">April</option>
-                <option value="5">May</option>
-                <option value="6">June</option>
-                <option value="7">July</option>
-                <option value="8">August</option>
-                <option value="9">September</option>
-                <option value="10">October</option>
-                <option value="11">November</option>
-                <option value="12">December</option>
-              </>
-            ) : (
-              <>
-                <option value="1">Janvier</option>
-                <option value="2">Février</option>
-                <option value="3">Mars</option>
-                <option value="4">Avril</option>
-                <option value="5">Peut</option>
-                <option value="6">Juin</option>
-                <option value="7">Juillet</option>
-                <option value="8">Août</option>
-                <option value="9">Septembre</option>
-                <option value="10">Octobre</option>
-                <option value="11">Novembre</option>
-                <option value="12">Décembre</option>
-              </>
-            )}
+            <>
+              <option value="1">{lang === "en" ? "January" : "Janvier"}</option>
+              <option value="2">
+                {lang === "en" ? "February" : "Février"}
+              </option>
+              <option value="3">{lang === "en" ? "March" : "Mars"}</option>
+              <option value="4">{lang === "en" ? "April" : "Avril"}</option>
+              <option value="5">{lang === "en" ? "May" : "Peut"}</option>
+              <option value="6">{lang === "en" ? "June" : "Juin"}</option>
+              <option value="7">{lang === "en" ? "July" : "Juillet"}</option>
+              <option value="8">{lang === "en" ? "August" : "Août"}</option>
+              <option value="9">
+                {lang === "en" ? "September" : "Septembre"}
+              </option>
+              <option value="10">
+                {lang === "en" ? "October" : "Octobre"}
+              </option>
+              <option value="11">
+                {lang === "en" ? "November" : "Novembre"}
+              </option>
+              <option value="12">
+                {lang === "en" ? "December" : "Décembre"}
+              </option>
+            </>
           </select>
           <div className="dropdownPos">
             <Image


### PR DESCRIPTION
This is because in app backends I'm pretty sure most logic would work better with numbers for months. This way it's easier to work with programmatically. It also means we don't have to confuse English and French months - we just use a number.